### PR TITLE
Add basic scanner modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,23 @@ volume = get_volume("ETHUSDT")
 
 Both functions accept optional `symbol` and `api_key` parameters if you want to
 specify them directly.
+
+## Market Screener
+
+The `scanner/market_screener.py` module implements a basic market
+scanning routine inspired by the four-layer early detection system.
+It fetches 24‑hour ticker data for all Binance pairs and applies
+simple filters for volume, price change percentage and RSI. The module
+returns coins that appear overbought or oversold according to the
+14‑period RSI indicator.
+
+Run it directly to print detected anomalies:
+
+```bash
+python scanner/market_screener.py
+```
+
+The other modules in the `scanner` package (`pattern_ai.py`,
+`onchain_radar.py` and `sentiment_sniper.py`) provide minimal
+placeholders that demonstrate how additional layers could be added in
+the future.

--- a/scanner/market_screener.py
+++ b/scanner/market_screener.py
@@ -1,0 +1,76 @@
+import os
+import requests
+
+BINANCE_TICKER_URL = "https://api.binance.com/api/v3/ticker/24hr"
+BINANCE_KLINE_URL = "https://api.binance.com/api/v3/klines"
+
+
+def fetch_all_tickers() -> list[dict]:
+    """Return 24hr ticker data for all trading pairs."""
+    resp = requests.get(BINANCE_TICKER_URL, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_klines(symbol: str, interval: str = "1h", limit: int = 100) -> list[dict]:
+    """Return klines for ``symbol`` using the given ``interval``."""
+    params = {"symbol": symbol, "interval": interval, "limit": limit}
+    resp = requests.get(BINANCE_KLINE_URL, params=params, timeout=10)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def rsi(prices: list[float], period: int = 14) -> float:
+    """Compute a simple RSI value for ``prices``."""
+    if len(prices) < period + 1:
+        raise ValueError("Not enough data for RSI")
+    gains = 0.0
+    losses = 0.0
+    for i in range(1, period + 1):
+        diff = prices[-i] - prices[-i - 1]
+        if diff > 0:
+            gains += diff
+        else:
+            losses += -diff
+    avg_gain = gains / period
+    avg_loss = losses / period
+    if avg_loss == 0:
+        return 100.0
+    rs = avg_gain / avg_loss
+    return 100 - (100 / (1 + rs))
+
+
+def screen_market(volume_min: float = 1_000_000.0,
+                  price_change_min: float = 5.0,
+                  rsi_period: int = 14,
+                  overbought: float = 70.0,
+                  oversold: float = 30.0) -> list[dict]:
+    """Screen all Binance pairs and return anomalies."""
+    anomalies = []
+    tickers = fetch_all_tickers()
+    for t in tickers:
+        symbol = t["symbol"]
+        volume = float(t["quoteVolume"])
+        change = float(t["priceChangePercent"])
+        if volume < volume_min or abs(change) < price_change_min:
+            continue
+        try:
+            data = fetch_klines(symbol, "1h", rsi_period + 1)
+            closes = [float(c[4]) for c in data]
+            rsi_val = rsi(closes, rsi_period)
+        except Exception:
+            continue
+        if rsi_val > overbought or rsi_val < oversold:
+            anomalies.append({
+                "symbol": symbol,
+                "volume": volume,
+                "change": change,
+                "rsi": rsi_val
+            })
+    return anomalies
+
+
+if __name__ == "__main__":
+    results = screen_market()
+    for item in results:
+        print(item)

--- a/scanner/onchain_radar.py
+++ b/scanner/onchain_radar.py
@@ -1,0 +1,51 @@
+"""Simple on-chain monitoring utilities.
+
+These functions use public blockchain explorer APIs to look for
+large transfers or token unlock events. They are intentionally
+lightweight and serve as placeholders for a more complete system.
+"""
+
+import os
+import requests
+
+ETHERSCAN_API = "https://api.etherscan.io/api"
+API_KEY = os.getenv("ETHERSCAN_API_KEY")
+
+
+def get_token_transfers(address: str, limit: int = 10) -> list[dict]:
+    """Return recent transfers involving ``address``."""
+    if not API_KEY:
+        raise RuntimeError("ETHERSCAN_API_KEY not set")
+    params = {
+        "module": "account",
+        "action": "tokentx",
+        "address": address,
+        "page": 1,
+        "offset": limit,
+        "sort": "desc",
+        "apikey": API_KEY,
+    }
+    resp = requests.get(ETHERSCAN_API, params=params, timeout=10)
+    resp.raise_for_status()
+    return resp.json().get("result", [])
+
+
+def has_large_transfer(address: str, threshold: float = 1_000_000) -> bool:
+    """Return ``True`` if ``address`` sent or received a large transfer."""
+    try:
+        transfers = get_token_transfers(address, 5)
+    except Exception:
+        return False
+    for t in transfers:
+        value = float(t.get("value", 0)) / (10 ** int(t.get("tokenDecimal", 0)))
+        if value >= threshold:
+            return True
+    return False
+
+
+if __name__ == "__main__":
+    addr = os.getenv("ADDRESS")
+    if addr:
+        print(has_large_transfer(addr))
+    else:
+        print("Set ADDRESS env var")

--- a/scanner/pattern_ai.py
+++ b/scanner/pattern_ai.py
@@ -1,0 +1,31 @@
+import requests
+import numpy as np
+
+from .market_screener import fetch_klines
+
+
+def deviation_score(symbol: str, interval: str = "1h", lookback: int = 48) -> float:
+    """Return a simple deviation score for the last half vs previous half."""
+    data = fetch_klines(symbol, interval, lookback * 2)
+    closes = [float(c[4]) for c in data]
+    if len(closes) < lookback * 2:
+        return 0.0
+    first = np.array(closes[:lookback])
+    second = np.array(closes[lookback:])
+    first_norm = first / first[0]
+    second_norm = second / second[0]
+    deviation = np.mean(np.abs(second_norm - first_norm))
+    return float(deviation)
+
+
+def pump_dump_risk(symbol: str) -> dict:
+    """Return a naive pump/dump risk score for ``symbol``."""
+    score = deviation_score(symbol)
+    return {
+        "symbol": symbol,
+        "risk_score": round(score * 100, 2)
+    }
+
+
+if __name__ == "__main__":
+    print(pump_dump_risk("BTCUSDT"))

--- a/scanner/sentiment_sniper.py
+++ b/scanner/sentiment_sniper.py
@@ -1,0 +1,36 @@
+"""Basic social media sentiment utilities.
+
+These are placeholders that illustrate how sentiment scanning could be
+integrated. They rely on environment variables for API keys and do not
+handle authentication or rate limits.
+"""
+
+import os
+import requests
+
+X_BEARER_TOKEN = os.getenv("X_BEARER_TOKEN")
+
+
+def search_x(keyword: str, limit: int = 10) -> list[dict]:
+    """Search recent posts on X (Twitter) containing ``keyword``."""
+    if not X_BEARER_TOKEN:
+        raise RuntimeError("X_BEARER_TOKEN not set")
+    url = "https://api.twitter.com/2/tweets/search/recent"
+    headers = {"Authorization": f"Bearer {X_BEARER_TOKEN}"}
+    params = {"query": keyword, "max_results": limit}
+    resp = requests.get(url, headers=headers, params=params, timeout=10)
+    resp.raise_for_status()
+    return resp.json().get("data", [])
+
+
+def keyword_mention_count(keyword: str) -> int:
+    """Return how many times ``keyword`` is mentioned recently."""
+    try:
+        posts = search_x(keyword, limit=100)
+    except Exception:
+        return 0
+    return len(posts)
+
+
+if __name__ == "__main__":
+    print(keyword_mention_count("listing"))


### PR DESCRIPTION
## Summary
- add a new `scanner` package with early detection utilities
- add Market Screener module with simple filters
- add placeholder modules for pattern deviation, on-chain checks and social sentiment
- document the screener in README

## Testing
- `python -m py_compile collector/crypto_data.py scanner/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686ca6894070832d97a9c0913764e435